### PR TITLE
Fix broken mono and CA cert

### DIFF
--- a/overlay/usr/local/migration/1.0.0.sh
+++ b/overlay/usr/local/migration/1.0.0.sh
@@ -2,13 +2,9 @@
 
 echo "Running migration for 1.0.0"
 
-echo "Remove mono dependency"
-pkg remove -fy mono6.8
+./install_bundled_mono.sh
 
 echo "Update CA certs and resync"
 pkg install -y ca_root_nss
+./remove_lets_encrypt_ca.sh
 cert-sync /usr/local/share/certs/ca-root-nss.crt
-
-echo "Patching mono to 6.8.0"
-pkg install -y /usr/local/migration/bin/mono-6.8.0.105.txz
-

--- a/overlay/usr/local/migration/1.0.0.sh
+++ b/overlay/usr/local/migration/1.0.0.sh
@@ -5,5 +5,10 @@ echo "Running migration for 1.0.0"
 echo "Remove mono dependency"
 pkg remove -fy mono6.8
 
+echo "Update CA certs and resync"
+pkg install -y ca_root_nss
+cert-sync /usr/local/share/certs/ca-root-nss.crt
+
 echo "Patching mono to 6.8.0"
 pkg install -y /usr/local/migration/bin/mono-6.8.0.105.txz
+

--- a/overlay/usr/local/migration/1.0.0.sh
+++ b/overlay/usr/local/migration/1.0.0.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "Running migration for 1.0.0"
+
+echo "Remove mono dependency"
+pkg remove -fy mono6.8
+
+echo "Patching mono to 6.8.0"
+pkg install -y /usr/local/migration/bin/mono-6.8.0.105.txz

--- a/overlay/usr/local/migration/install_bundled_mono.sh
+++ b/overlay/usr/local/migration/install_bundled_mono.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Remove mono dependency"
 pkg remove -fy mono6.8

--- a/overlay/usr/local/migration/install_bundled_mono.sh
+++ b/overlay/usr/local/migration/install_bundled_mono.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+
+echo "Remove mono dependency"
+pkg remove -fy mono6.8
+
+echo "Patching mono to 6.8.0"
+pkg install -y /usr/local/migration/bin/mono-6.8.0.105.txz

--- a/overlay/usr/local/migration/install_bundled_mono.sh
+++ b/overlay/usr/local/migration/install_bundled_mono.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 echo "Remove mono dependency"
 pkg remove -fy mono6.8

--- a/overlay/usr/local/migration/remove_lets_encrypt_ca.sh
+++ b/overlay/usr/local/migration/remove_lets_encrypt_ca.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 echo "Patching CA certs, removing expired Let's Encrypt cert"
 ca_file=/usr/local/share/certs/ca-root-nss.crt

--- a/overlay/usr/local/migration/remove_lets_encrypt_ca.sh
+++ b/overlay/usr/local/migration/remove_lets_encrypt_ca.sh
@@ -1,5 +1,6 @@
 #/bin/bash
 
+echo "Patching CA certs, removing expired Let's Encrypt cert"
 ca_file=/usr/local/share/certs/ca-root-nss.crt
 
 i=0
@@ -25,3 +26,5 @@ if [ $cert_line -ne 0 ]
 then
   sed -i '' "${cert_line},${end_line}d" "${ca_file}"
 fi
+
+echo "CA cert patch complete"

--- a/overlay/usr/local/migration/remove_lets_encrypt_ca.sh
+++ b/overlay/usr/local/migration/remove_lets_encrypt_ca.sh
@@ -1,0 +1,27 @@
+#/bin/bash
+
+ca_file=/usr/local/share/certs/ca-root-nss.crt
+
+i=0
+cert_line=0
+
+while IFS= read -r line
+do
+  i=$((i+1))
+
+  if [ "$line" = "Certificate:" ]
+  then
+    cert_line=$i
+  fi
+
+  if [ "$line" = "Ob8VZRzI9neWagqNdwvYkQsEjgfbKbYK7p2CNTUQ" ]
+  then
+    end_line=$((i+1))  # Last PEM bytes, row below this one is the -----END CERTIFICATE-----
+    break
+  fi
+done < ${ca_file}
+
+if [ $cert_line -ne 0 ]
+then
+  sed -i '' "${cert_line},${end_line}d" "${ca_file}"
+fi

--- a/overlay/usr/local/migration/remove_lets_encrypt_ca.sh
+++ b/overlay/usr/local/migration/remove_lets_encrypt_ca.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Patching CA certs, removing expired Let's Encrypt cert"
 ca_file=/usr/local/share/certs/ca-root-nss.crt
@@ -22,7 +22,7 @@ do
   fi
 done < ${ca_file}
 
-if [ $cert_line -ne 0 ]
+if [ "$end_line" != "" ]
 then
   sed -i '' "${cert_line},${end_line}d" "${ca_file}"
 fi

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 
-echo "Remove mono dependency"
-pkg remove -fy mono6.8
-
-echo "Patching mono to 6.8.0"
-pkg install -y /usr/local/migration/bin/mono-6.8.0.105.txz
+./usr/local/migration/remove_lets_encrypt_ca.sh
+./usr/local/migration/install_bundeled_mono.sh
 
 # Need to make jackett user own /usr/local/share/jackett folder
 # this is needed for update to work properly

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ./usr/local/migration/remove_lets_encrypt_ca.sh
-./usr/local/migration/install_bundeled_mono.sh
+./usr/local/migration/install_bundled_mono.sh
 
 # Need to make jackett user own /usr/local/share/jackett folder
 # this is needed for update to work properly

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+echo "Remove mono dependency"
+pkg remove -fy mono6.8
+
 echo "Patching mono to 6.8.0"
 pkg install -y /usr/local/migration/bin/mono-6.8.0.105.txz
 

--- a/post_update.sh
+++ b/post_update.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 ./usr/local/migration/0.0.1.sh
+./usr/local/migration/1.0.0.sh
 
 chown -R jackett /usr/local/share/jackett
 sysrc -f /etc/rc.conf jackett_enable="YES"


### PR DESCRIPTION
* Make sure the bundled mono version is installed (remove the dependent and buggy 6.8.0.123 version)
* Quickfix bugs with Let's Encrypt CA cert by removing it from the `ca_root_ns` installed file

Possible solution for: https://github.com/fulder/iocage-plugin-jackett/issues/4